### PR TITLE
DDCYLS-5310 - added play.filters.headers.contentTypeOptions = nosniff 

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,6 +22,7 @@ play.http.errorHandler = "handlers.ErrorHandler"
 play.filters.enabled += "uk.gov.hmrc.play.bootstrap.frontend.filters.SessionIdFilter"
 
 play.filters.enabled += play.filters.csp.CSPFilter
+play.filters.headers.contentTypeOptions = nosniff
 
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"


### PR DESCRIPTION
This is to address security alert X-Content-Type-Options Header Missing